### PR TITLE
[WIP] Upgrade nom to version 4 

### DIFF
--- a/malice/Cargo.toml
+++ b/malice/Cargo.toml
@@ -15,8 +15,8 @@ default = []
 cpp = ["alice-sys"]
 
 [dependencies]
-nom = "3.2.1"
-root-io = "0.1.1"
+nom = "4"
+root-io = { path = "../root-io" }
 failure = "0.1.1"
 bitflags = "1.0.1"
 

--- a/malice/src/dataset_rust.rs
+++ b/malice/src/dataset_rust.rs
@@ -1,7 +1,7 @@
 //! Structs and iterators concerned with iterating over events stored in `root_io::Tree`s.
 
 use failure::Error;
-use nom;
+use nom::{self, be_u8, be_u16, be_u32, be_u64, be_i8, be_i32, be_f32};
 
 use root_io::tree_reader::{ColumnFixedIntoIter, ColumnVarIntoIter, Tree};
 use root_io::core::types::ClassInfo;
@@ -32,7 +32,6 @@ pub struct DatasetIntoIter {
 impl DatasetIntoIter {
     /// Create a new `DatasetIntoIter` from the given `root_io::Tree`. The `Tree` must be a so-called "ESD" tree.
     pub fn new(t: &Tree) -> Result<DatasetIntoIter, Error> {
-        use nom::{be_u8, be_u16, be_u32, be_u64, be_i8, be_i32, be_f32};
         let track_counter: Vec<_> = ColumnFixedIntoIter::new(&t, "Tracks", be_u32)?.collect();
         Ok(DatasetIntoIter {
             aliesdrun_frunnumber: ColumnFixedIntoIter::new(&t, "AliESDRun.fRunNumber", be_i32)?,
@@ -117,7 +116,6 @@ fn parse_trigger_classes(input: &[u8]) -> nom::IResult<&[u8], Vec<String>> {
 /// This function reconstructs a float from the exponent and mantissa
 /// TODO: Use ByteOrder crate to be cross-platform!
 fn parse_custom_mantissa(input: &[u8], nbits: usize) -> nom::IResult<&[u8], f32> {
-    use nom::{be_u8, be_u16};
     pair!(input, be_u8, be_u16).map(|(i, (exp, man))| {
         // let nbits = 8;
         let mut s = exp as u32;

--- a/root-io/Cargo.toml
+++ b/root-io/Cargo.toml
@@ -10,14 +10,13 @@ keywords = ["root", "cern", "alice", "lhc", "physics"]
 categories = ["parser-implementations", "science", "data-structures"]
 license = "MPL-2.0"
 
-
 [dependencies]
 flate2 = "0.2"
-xz2 = "^0.1.4"
+xz2 = "0.1"
 bitflags = "1.0.0"
-quote = "0.3.15"
+quote = "0.3"
 failure = "0.1.0"
 
 [dependencies.nom]
-version = "^3"
+version = "4"
 #features = ["nightly", "verbose-errors"] # For better error messages

--- a/root-io/Cargo.toml
+++ b/root-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "root-io"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["cbourjau <christian.bourjau@cern.ch>"]
 exclude = ["*test_data/", "*.root"]
 description = "Reading of `.root` binary files which are commonly used in particle physics"

--- a/root-io/src/core/file.rs
+++ b/root-io/src/core/file.rs
@@ -6,10 +6,9 @@ use std::io::{BufReader, Seek, SeekFrom, Read};
 
 use failure::Error;
 use nom::{IResult, *};
-use crate::core::types::Context;
 
 use MAP_OFFSET;
-use ::core::*;
+use ::core::{*, Context};
 use ::code_gen::rust::{ToNamedRustParser, ToRustStruct};
 
 /// `RootFile` wraps the most basic information of a ROOT file.

--- a/root-io/src/core/file.rs
+++ b/root-io/src/core/file.rs
@@ -250,7 +250,7 @@ fn parse_buffer<R, F, O>(reader: &mut BufReader<R>, buf_size: usize, f: F)
             // Reset seek position and try again with updated buf size
             reader.seek(SeekFrom::Current(-(read_bytes as i64)))?;
             match needed {
-                Needed::Size(s) => parse_buffer(reader, s, f),
+                Needed::Size(s) => parse_buffer(reader, read_bytes + s, f),
                 _ => parse_buffer(reader, buf_size + 1000, f),
             }
         },

--- a/root-io/src/core/file_item.rs
+++ b/root-io/src/core/file_item.rs
@@ -35,7 +35,7 @@ impl FileItem {
     pub fn name(&self) -> String {
         format!("`{}` of type `{}`", self.tkey_hdr.obj_name, self.tkey_hdr.class_name)
     }
-    
+
 
     /// Read (and posibly decompress) data from disk and parse it as
     /// the appropriate type using the TStreamerInfo types.
@@ -73,7 +73,7 @@ impl FileItem {
         // wrap parser in a byte count
         let res = length_value!(s, checked_byte_count, apply!(&parser, &context));
         match res {
-            IResult::Done(_, obj) => Ok(obj),
+            Ok((_, obj)) => Ok(obj),
             _ => Err(format_err!("Supplied parser failed!"))
         }
     }
@@ -84,7 +84,7 @@ impl FileItem {
 mod tests {
     use std::path::{PathBuf};
     use core::RootFile;
-    
+
     #[test]
     fn open_simple() {
         let path = PathBuf::from("./src/test_data/simple.root");

--- a/root-io/src/core/parsers.rs
+++ b/root-io/src/core/parsers.rs
@@ -25,7 +25,7 @@ fn is_byte_count(v: u32) -> bool {
 }
 
 /// Check that the given byte count is not zero after applying bit mask
-/// 
+///
 named!(
     #[doc="Return the size in bytes of the following object in the
     input. The count is the remainder of this object minus the size
@@ -185,7 +185,7 @@ named!(
     do_parse!(magic: take_str!(2) >>
               _header: take!(7) >>
               comp_buf: call!(nom::rest) >>
-              ret: expr_res!(decode_reader(comp_buf, magic)) >> 
+              ret: expr_res!(decode_reader(comp_buf, magic)) >>
               (ret)
     )
 );
@@ -278,15 +278,17 @@ pub fn raw<'s, 'c>(input: &'s[u8], context: &'c Context) -> nom::IResult<&'s[u8]
 /// Same as `raw` but doesn't require a `Context` as input. Panics if
 /// a `Context` is required to parse the underlying buffer (i.e., the
 /// given buffer contains a reference to some other part of the file.
-pub fn raw_no_context(input: &[u8]) -> nom::IResult<&[u8], (ClassInfo, &[u8])>
+pub fn raw_no_context(input: &[u8]) ->
+    nom::IResult<&[u8], (ClassInfo, &[u8])>
 {
     use self::ClassInfo::*;
     let first = do_parse!(input,
               ci: classinfo >>
-              rest: call!(nom::rest) >> 
+              rest: call!(nom::rest) >>
               (ci, rest)
     );
-    if first.is_done() {
+
+    if first.is_ok() {
         let (_, (ci, rest)) = first.unwrap();
         let obj = match ci {
             References(0) => value!(rest, &input[..0]),
@@ -294,7 +296,7 @@ pub fn raw_no_context(input: &[u8]) -> nom::IResult<&[u8], (ClassInfo, &[u8])>
             // If its a reference to any other thing but 0 it needs a context
             _ => panic!("Object needs context!"),
         };
-        obj.map(|o| (ci, o))
+        obj.map(|(i, o)| (i, (ci, o)))
     } else {
         first
     }
@@ -317,4 +319,3 @@ mod classinfo_test {
         assert_eq!(i.len(), 352);
     }
 }
-

--- a/root-io/src/core/tstreamerinfo.rs
+++ b/root-io/src/core/tstreamerinfo.rs
@@ -1,7 +1,10 @@
 use quote::*;
-use nom::*;
+// use nom::*;
+use nom::HexDisplay;
+use nom::{IResult, be_u16, be_u32};
 
-use ::core::*;
+
+use crate::core::{*, Context};
 use ::code_gen::rust::{ToRustType, ToRustParser, ToNamedRustParser, ToRustStruct};
 use ::code_gen::utils::{type_is_core};
 
@@ -33,7 +36,7 @@ pub(crate) fn tstreamerinfo<'s, 'c>(input: &'s[u8], context: &'c Context) -> IRe
                   let data_members = data_members.iter()
                       .filter_map(|el| {
                           match tstreamer(el) {
-                              IResult::Done(_, v) => Some(v),
+                              Ok((_, v)) => Some(v),
                               _ => {println!("Failed to parse TStreamer for {}:\n{}",
                                              el.classinfo, el.obj.to_hex(16));
                                     None
@@ -83,7 +86,7 @@ impl ToNamedRustParser for TStreamerInfo {
     fn parser_name(&self) -> Tokens {
         let ret = Ident::new(self.named.name.to_lowercase());
         quote!(#ret)
-    }    
+    }
 
     fn to_named_parser(&self) -> Tokens {
         if type_is_core(self.named.name.as_str()) {

--- a/root-io/src/core/tstreamerinfo.rs
+++ b/root-io/src/core/tstreamerinfo.rs
@@ -1,10 +1,9 @@
 use quote::*;
-// use nom::*;
 use nom::HexDisplay;
 use nom::{IResult, be_u16, be_u32};
 
-
-use crate::core::{*, Context};
+use ::core::{TStreamer, tstreamer, TNamed, Context};
+use ::core::parsers::*;
 use ::code_gen::rust::{ToRustType, ToRustParser, ToNamedRustParser, ToRustStruct};
 use ::code_gen::utils::{type_is_core};
 

--- a/root-io/src/tests/read_esd.rs
+++ b/root-io/src/tests/read_esd.rs
@@ -52,7 +52,7 @@ struct Model {
     primaryvertex_alivertex_fncontributors: i32,
     aliesdrun_frunnumber: i32,
     aliesdrun_ftriggerclasses: Vec<String>,
-    aliesdheader_ftriggermask: u64, 
+    aliesdheader_ftriggermask: u64,
     tracks_fx: Vec<f32>,
     tracks_fp: Vec<[f32; 5]>,
     tracks_falpha: Vec<f32>,
@@ -98,7 +98,7 @@ fn parse_trigger_classes(input: &[u8]) -> IResult<&[u8], Vec<String>> {
                     ClassInfo::References(0) => "".to_string(),
                     _ => {
                         match tnamed(el.as_slice()).map(|tn| tn.name) {
-                            IResult::Done(_, n) => n,
+                            Ok((_, n)) => n,
                             _ => panic!()
                         }
                     }
@@ -123,7 +123,7 @@ fn parse_its_chi2(input: &[u8]) -> IResult<&[u8], f32> {
         f32::from_bits(s)
     })
 }
-    
+
 
 #[test]
 #[ignore]

--- a/root-io/src/tree_reader/branch.rs
+++ b/root-io/src/tree_reader/branch.rs
@@ -3,7 +3,9 @@ use std::path::PathBuf;
 use nom::*;
 
 use core::parsers::*;
-use core::types::*;
+// use crate::core::types::*;
+use crate::core::types::{Raw, Context};
+
 use code_gen::rust::ToRustType;
 
 use tree_reader::container::Container;
@@ -182,4 +184,3 @@ fn tbranch<'s>(input: &'s [u8], context: & Context<'s>) -> IResult<&'s [u8], TBr
                   }
               }))
 }
-

--- a/root-io/src/tree_reader/branch.rs
+++ b/root-io/src/tree_reader/branch.rs
@@ -2,9 +2,8 @@ use std::io::SeekFrom;
 use std::path::PathBuf;
 use nom::*;
 
-use core::parsers::*;
-// use crate::core::types::*;
-use crate::core::types::{Raw, Context};
+use ::core::parsers::*;
+use ::core::types::{Raw, Context};
 
 use code_gen::rust::ToRustType;
 

--- a/root-io/src/tree_reader/column_fixed_into_iter.rs
+++ b/root-io/src/tree_reader/column_fixed_into_iter.rs
@@ -96,9 +96,9 @@ impl<T> ColumnFixedIntoIter<T> {
                 // Read and decompress data into a vec
                 .flat_map(|c| c.raw_data())
                 .flat_map(move |(n_entries, raw_slice)| {
-                    let s: &[u8] = raw_slice.as_slice(); 
+                    let s: &[u8] = raw_slice.as_slice();
                     match count!(s, p, n_entries as usize) {
-                        IResult::Done(_, o) => o,
+                        Ok((_, o)) => o,
                         _ => panic!("Parser failed unexpectedly!"),
                     }
                 }));

--- a/root-io/src/tree_reader/column_var_into_iter.rs
+++ b/root-io/src/tree_reader/column_var_into_iter.rs
@@ -31,7 +31,7 @@ impl<T> ColumnVarIntoIter<T> {
         // `el_counter[N]` times. TODO: This is not what currently
         // happens! Currently, I'm parsing all _elements_ of a basket,
         // ignoring the size of each event. I then chunk the numer of
-        // elements into the size of the entry in the `next` function        
+        // elements into the size of the entry in the `next` function
         let br: &TBranch = tr.branches().iter()
             .find(|b| b.name == name)
             .ok_or_else(|| format_err!("Branch {} not found in tree: \n {:#?}",
@@ -57,7 +57,7 @@ impl<T> ColumnVarIntoIter<T> {
                 .flat_map(move |((n_entries_in_buf, raw_slice), n_elems)| {
                     let s: &[u8] = raw_slice.as_slice();
                     match count!(s, p, n_elems as usize) {
-                        IResult::Done(_, o) => o,
+                        Ok((_, o)) => o,
                         _ => panic!("Parser failed unexpectedly! {}, {}", n_entries_in_buf, s.len()),
                     }})
         );

--- a/root-io/src/tree_reader/container.rs
+++ b/root-io/src/tree_reader/container.rs
@@ -20,7 +20,7 @@ impl Container {
         match self {
             Container::InMemory(buf) => {
                 match tbasket2vec(buf.as_slice()) {
-                    IResult::Done(_, v) => Ok(v),
+                    Ok((_, v)) => Ok(v),
                     _ => Err(format_err!("tbasket2vec parser failed"))
                 }
             },
@@ -32,7 +32,7 @@ impl Container {
                 reader.read_exact(&mut buf)?;
                 // println!("{:#?}", tbasket(buf.as_slice(), be_u32).unwrap().1);
                 match tbasket2vec(buf.as_slice()) {
-                    IResult::Done(_, v) => Ok(v),
+                    Ok((_, v)) => Ok(v),
                     _ => Err(format_err!("tbasket2vec parser failed"))
                 }
             }

--- a/root-io/src/tree_reader/leafs.rs
+++ b/root-io/src/tree_reader/leafs.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use nom::*;
 use quote::{Ident, Tokens};
 
-use crate::core::{*, Context};
+use ::core::{*, Context};
 use code_gen::rust::ToRustType;
 
 #[derive(Debug, Clone)]

--- a/root-io/src/tree_reader/leafs.rs
+++ b/root-io/src/tree_reader/leafs.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use nom::*;
 use quote::{Ident, Tokens};
 
-use core::*;
+use crate::core::{*, Context};
 use code_gen::rust::ToRustType;
 
 #[derive(Debug, Clone)]
@@ -60,7 +60,7 @@ impl fmt::Debug for TLeaf {
                 writeln!(f, "String: {:#?}", leaf),
             TLeaf::Element(ref leaf) =>
                 writeln!(f, "Element: {:#?}", leaf),
-            TLeaf::Object(ref leaf_name, ref leaf) => 
+            TLeaf::Object(ref leaf_name, ref leaf) =>
                 writeln!(f, "`{}`: {:#?}", leaf_name, leaf),
         }
     }

--- a/root-io/src/tree_reader/tree.rs
+++ b/root-io/src/tree_reader/tree.rs
@@ -2,9 +2,8 @@ use std::fmt;
 use std::ops::Deref;
 use nom::*;
 
-use core::parsers::*;
-use core::types::*;
-use crate::core::types::Context;
+use ::core::parsers::*;
+use ::core::types::{TNamed, Context};
 
 use tree_reader::branch::TBranch;
 use tree_reader::branch::tbranch_hdr;

--- a/root-io/src/tree_reader/tree.rs
+++ b/root-io/src/tree_reader/tree.rs
@@ -4,6 +4,7 @@ use nom::*;
 
 use core::parsers::*;
 use core::types::*;
+use crate::core::types::Context;
 
 use tree_reader::branch::TBranch;
 use tree_reader::branch::tbranch_hdr;
@@ -111,7 +112,7 @@ pub fn ttree<'s>(input: &'s[u8], context: &Context) -> IResult<&'s[u8], Tree> {
                                                 map!(call!(_curried_raw), |r| r.obj.to_vec()),
                                                 Some));
     let grab_checked_byte_count = |i| length_data!(i, checked_byte_count);
-    let wrapped_tobjarray = |i: &'s[u8]| length_value!(i, checked_byte_count, apply!(tobjarray, context));    
+    let wrapped_tobjarray = |i: &'s[u8]| length_value!(i, checked_byte_count, apply!(tobjarray, context));
     do_parse!(input,
               ver: be_u16 >>
               tnamed: length_value!(checked_byte_count, tnamed) >>


### PR DESCRIPTION
I thought I'd update the root-io dependencies.

nom 4 changes the implementation of IResult enum from `nom::IResult<I, O, E>` to `std::Result<(I, O), E>`, so a few closures and matches had to be changed to accept tuples, and remove `IResult::Done` references.

It compiles but it doesn't pass the `core::file_item::tests::open_simple` & `tests::high_level_io::root_file_methods` tests due to reaching the end of file too early.

I don't think I changed any logic, so it must be a new nom behavior upon (I'm guessing) reading the last byte.

Any suggestions?

Also, I updated the versions to reflect an update in the dependencies.

Hope all is well,
Andrew